### PR TITLE
Migration to CKAN 2.3

### DIFF
--- a/ckanext/bcgov/commands/edc_commands.py
+++ b/ckanext/bcgov/commands/edc_commands.py
@@ -8,6 +8,8 @@
 from ckan import model
 from ckan.lib.cli import CkanCommand
 from ckan.logic import get_action, NotFound
+from ckan.lib.datapreview import (get_default_view_plugins,
+                                  add_views_to_dataset_resources)
 
 import logging
 import os
@@ -35,6 +37,7 @@ class EdcCommand(CkanCommand):
         delete-all-orgs     Delete all organizations
         purge-records       Purge all already-deleted datasets
         purge-revisions     Purge all already-deleted revisions
+        create-views         Create CKAN 2.3 resource views
     '''
     summary = __doc__.split('\n')[0]
     usage = __doc__
@@ -80,6 +83,8 @@ class EdcCommand(CkanCommand):
             self.purge_records()
         elif cmd == 'purge-revisions':
             self.purge_revisions()
+        elif cmd == 'create_views':
+            self.create_views()
         else:
             log.error('Command "%s" not defined' % (cmd,))
 
@@ -307,3 +312,15 @@ class EdcCommand(CkanCommand):
         print 'Purge errors : '
         for msg in msgs:
             print msg
+
+
+    def create_views(self):
+        #TODO: we need this method because of this bug - @deniszgonjanin
+        #https://github.com/ckan/ckan/issues/2532
+        view_plugins = [view_plugin.info()['name']
+                        for view_plugin in get_default_view_plugins()]
+
+        for p in get_action('package_list')({},{}):
+            package = get_action('package_show')({}, {'id':p})
+
+            add_views_to_dataset_resources({}, package, view_types=view_plugins)

--- a/ckanext/bcgov/commands/edc_commands.py
+++ b/ckanext/bcgov/commands/edc_commands.py
@@ -82,7 +82,7 @@ class EdcCommand(CkanCommand):
             self.purge_records()
         elif cmd == 'purge-revisions':
             self.purge_revisions()
-        elif cmd == 'create_views':
+        elif cmd == 'create-views':
             self.create_views()
         else:
             log.error('Command "%s" not defined' % (cmd,))

--- a/ckanext/bcgov/controllers/package.py
+++ b/ckanext/bcgov/controllers/package.py
@@ -1,6 +1,6 @@
-# Copyright  2015, Province of British Columbia 
-# License: https://github.com/bcgov/ckanext-bcgov/blob/master/license 
- 
+# Copyright  2015, Province of British Columbia
+# License: https://github.com/bcgov/ckanext-bcgov/blob/master/license
+
 #Author: Kahlegh Mamakani Highwaythree Solutions Inc.
 #Created on Jan 28 2014
 
@@ -339,41 +339,41 @@ class EDCPackageController(PackageController):
         else:
             redirect(toolkit.url_for(form_urls[dataset_type]))
 
-# 
+#
 #     def edc_edit(self, id, data=None, errors=None, error_summary=None):
 #         '''
 #         Gets the latest package data saved before applying package update.
 #         It is used to get the previous dataset state and compare it with the current state
 #         to see if the state has been changed.
 #         '''
-# 
+#
 #         c.form_style = 'edit'
 #         context = {'model': model, 'session': model.Session,
 #                    'user': c.user or c.author, 'auth_user_obj': c.userobj,
 #                    'save': 'save' in request.params}
 #         old_data = None
-# 
+#
 #         if not context['save'] or data :
 #             old_data = get_action('package_show')(context, {'id': id})
 #             EDCPackageController.old_state = old_data['edc_state']
-# 
+#
 #         result = super(EDCPackageController, self).edit(id, data, errors, error_summary)
-# 
+#
 #         return result
 
 #     def _form_save_redirect(self, pkgname, action, package_type=None):
 #         '''This overrides ckan's _form_save_redirect method of package controller class
 #         so that it can be called after the data has been recorded and the package has been updated.
 #         '''
-# 
+#
 #         context = {'model': model, 'session': model.Session,
 #                    'user': c.user or c.author, 'auth_user_obj': c.userobj}
-# 
+#
 #         new_data =  get_action('package_show')(context, {'id': pkgname})
 #         if new_data:
 #             check_record_state(EDCPackageController.old_state, new_data, pkgname)
 #             EDCPackageController.old_state = new_data['edc_state']
-# 
+#
 #         assert action in ('new', 'edit')
 #         url = request.params.get('return_to') or \
 #             config.get('package_%s_return_url' % action)
@@ -396,9 +396,13 @@ class EDCPackageController(PackageController):
         from ckanext.bcgov.util.helpers import record_is_viewable
         if not record_is_viewable(c.pkg_dict, c.userobj) :
             abort(401, _('Unauthorized to read package %s') % id)
-        
+
+        #TODO: find out if/why comparing times is neccessary? - @deniszgonjanin
         metadata_modified_time = from_utc(c.pkg_dict['metadata_modified'])
-        revision_timestamp_time = from_utc(c.pkg_dict['revision_timestamp'])
+        revision = get_action('revision_show')(
+            {}, {'id': c.pkg_dict['revision_id']}
+        )
+        revision_timestamp_time = from_utc(revision['timestamp'])
 
         if (metadata_modified_time >= revision_timestamp_time):
             timestamp = metadata_modified_time.strftime('%a, %d %b %Y %H:%M:%S GMT')

--- a/ckanext/bcgov/forms/dataset_form.py
+++ b/ckanext/bcgov/forms/dataset_form.py
@@ -1,6 +1,6 @@
-# Copyright  2015, Province of British Columbia 
-# License: https://github.com/bcgov/ckanext-bcgov/blob/master/license 
- 
+# Copyright  2015, Province of British Columbia
+# License: https://github.com/bcgov/ckanext-bcgov/blob/master/license
+
 import logging
 
 from ckan.logic import get_action, NotFound
@@ -104,7 +104,6 @@ class EDC_DatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     #Customize schema for EDC Application Dataset
     def _modify_package_schema(self, schema):
         schema.update({
-                        'tag_string' : [not_empty],
                         'title' : [not_empty, check_dashes, check_duplicates, unicode],
                         'notes' : [not_empty, unicode],
                         'org' : [not_empty, convert_to_extras],

--- a/ckanext/bcgov/forms/dataset_form.py
+++ b/ckanext/bcgov/forms/dataset_form.py
@@ -1,6 +1,6 @@
-# Copyright  2015, Province of British Columbia
-# License: https://github.com/bcgov/ckanext-bcgov/blob/master/license
-
+# Copyright  2015, Province of British Columbia 
+# License: https://github.com/bcgov/ckanext-bcgov/blob/master/license 
+ 
 import logging
 
 from ckan.logic import get_action, NotFound
@@ -104,6 +104,7 @@ class EDC_DatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     #Customize schema for EDC Application Dataset
     def _modify_package_schema(self, schema):
         schema.update({
+                        'tag_string' : [not_empty],
                         'title' : [not_empty, check_dashes, check_duplicates, unicode],
                         'notes' : [not_empty, unicode],
                         'org' : [not_empty, convert_to_extras],

--- a/ckanext/bcgov/templates/package/resource_read.html
+++ b/ckanext/bcgov/templates/package/resource_read.html
@@ -80,7 +80,7 @@
         </div>
       </div>
       {% block data_preview %}
-        {{ h.resource_preview(c.resource, c.package) }}
+        {{ super() }}
       {% endblock %}
     </section>
   {% endblock %}

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,3 +1,3 @@
-ckan==2.2.1
+ckan==2.3
 pycurl==7.19.5
 validate_email==1.2


### PR DESCRIPTION
This PR addresses code changes for migrating the catalogue to CKAN 2.3. In addition, a few other things need to happen for a successful migration:

##### Setup
- Run database migration for 2.3. This can be done with `paster db upgrade’
- `pdf_preview` extension no longer exists. Need to install https://github.com/ckan/ckanext-pdfview.git
- CKAN 2.3. uses the new ResourceView feature instead of resource previews. For geographic views, this extension needs to be installed: https://github.com/pduchesne/ckanext-geoview
- There is a new schema version for CKAN 2.3. This can be retrieved from the CKAN source here: https://github.com/ckan/ckan/blob/ckan-2.3/ckan/config/solr/schema.xml.
- Because of the new schema, clean the existing index, restart SOLR, and reindex everything.

##### Configuration options:
- `ckanext.geoview.ol_viewer.formats = wms kml geojson`
- change `ckan.plugins = … text_preview pdf_preview recline_preview` to `ckan.plugins = … text_view pdf_view recline_view`
- `ckan.views.default_views = text_view recline_view geo_view pdf_view`

##### Creating the new Resource Views:
The new views for geospatial, tabular, pdf, etc... will not appear automatically like the old resource previews. They need to be created via a paster command:
`paster --plugin=ckanext-bcgov edc_command create-views`