### PR TITLE
change urls in disqus to protocol-relative

### DIFF
--- a/ckanext/bcgov/templates/package/comments_block.html
+++ b/ckanext/bcgov/templates/package/comments_block.html
@@ -3,7 +3,7 @@
   <div id="disqus_messages" style="display: none;"></div>
   <div id="disqus_num_comments"></div>
   <div id="disqus_add_comment" style="display: none;">
-    <div class="user-avatar"><img src="http://a.disquscdn.com/uploads/users/9087/2489/avatar92.jpg?1389868656"></div>
+    <div class="user-avatar"><img src="//a.disquscdn.com/uploads/users/9087/2489/avatar92.jpg?1389868656"></div>
     <div id="comment_box">
         <form id="add_comment_form">
             <textarea name="message" class="message" placeholder="Add a comment"></textarea>
@@ -22,7 +22,7 @@
     <div class="empty">No comments have been posted yet.</div>
     <div class="post">
       <div class="post-content">
-        <div class="post-avatar"><img src="http://a.disquscdn.com/uploads/users/9087/2489/avatar92.jpg?1389868656"></div>
+        <div class="post-avatar"><img src="//a.disquscdn.com/uploads/users/9087/2489/avatar92.jpg?1389868656"></div>
         <div class="post-header">
             <span class="post-author"></span> <span class="bullet">&bull;</span> <span class="post-time"></span>
         </div>
@@ -46,7 +46,7 @@
     </div>
   </div>
   <div id="disqus-brand">
-    <a href="http://disqus.com"><img src="https://a.disquscdn.com/dotcom/d-e357401/img/brand/disqus-social-icon-dark-transparent.png"></a>
+    <a href="http://disqus.com"><img src="//a.disquscdn.com/dotcom/d-e357401/img/brand/disqus-social-icon-dark-transparent.png"></a>
   </div>
   <script type="text/javascript">
     var disqus_identifier = '{{ identifier }}';


### PR DESCRIPTION
The old links in disqus comments section are hard coded to http protocol. Downloading those files in an https protocol will issue mixed content errors, and pose security danger.
Instead of hardcoding to either http or https, '//' makes the url protocol-relative, which means the link will choose to use the protocol of the site.