### PR TITLE
block user registration form

### DIFF
--- a/ckanext/bcgov/controllers/user.py
+++ b/ckanext/bcgov/controllers/user.py
@@ -226,3 +226,4 @@ class EDCUserController(UserController):
 
     def register(self):
         return render('user/new.html')
+        

--- a/ckanext/bcgov/controllers/user.py
+++ b/ckanext/bcgov/controllers/user.py
@@ -225,5 +225,19 @@ class EDCUserController(UserController):
         return render('user/dashboard_organizations.html')
 
     def register(self):
+        context = {'model': model, 'session': model.Session,
+                   'user': c.user or c.author,
+                   'auth_user_obj': c.userobj,
+                   'schema': self._new_form_to_db_schema(),
+                   'save': 'save' in request.params}
+
+        try:
+            check_access('user_create', context)
+        except NotAuthorized:
+            abort(401, _('Unauthorized to create a user'))
+
+        if c.user:
+            # #1799 Don't offer the registration form if already logged in
+            return render('user/logout_first.html')
+
         return render('user/new.html')
-        


### PR DESCRIPTION
The problem:
With edc-idir plugin enabled, users cannot have access to /user/register on the UI, but they can write scripts to POST form info to /user/register. This is not taken care of by IAuthFunctions.

Desired situation and solution:
If a user is logged in, access to /user/register will ask him or her to log out first, just like ckan
If an unlogged in user tries to access /user/register, use the behaviour from edc-idir.
SOLUTION is the combine the behaviour of those two packages, and make our own customized register method.