### PR TITLE
CITZEDC573 - Added IDs to elements for selenium

### DIFF
--- a/ckanext/bcgov/templates/package/edc_type_form.html
+++ b/ckanext/bcgov/templates/package/edc_type_form.html
@@ -21,7 +21,7 @@
           		{%- endtrans -%}
         	</p>
       	{% endblock #}
-		<button class="btn btn-primary" type="submit" name="save">
+		<button id="create-dataset" class="btn btn-primary" type="submit" name="save">
 				{% block save_button_text %}
 					{{ _('Create Dataset') }}
 				{% endblock %}

--- a/ckanext/bcgov/templates/package/search.html
+++ b/ckanext/bcgov/templates/package/search.html
@@ -10,6 +10,15 @@
 	{% if h.check_access('package_create') and (admin_org or editor_org or c.userobj.sysadmin == True) %}
 		<div class="page_primary_action">
 			{% link_for _('Add Dataset'), controller='ckanext.bcgov.controllers.package:EDCPackageController', action='typeSelect', class_='btn btn-primary', icon='plus-sign-alt' %}
+			<script id="change-add-dataset-button">
+			// This adds the id attribute to the Add Dataset button
+			//  because link_for doesn't have a way to add an id attribute
+			//  to the element it creates
+			// IE doesn't support document.currentScript
+			var me = document.currentScript || document.getElementById('change-add-dataset-button');
+			var addDataset = me.previousElementSibling;
+			addDataset.id = "add-dataset";
+			</script>
 		</div>
 	{% endif %}
 {% endblock %}
@@ -51,23 +60,27 @@
   {{ h.snippet('snippets/package_list.html', packages=c.page.items, logged_in=c.user, user=c.userobj, admin_org=admin_org, editor_org=editor_org, mem_org=mem_org, controller=c.controller) }}
 {% endblock %}
 
-{% block secondary_content %}
-  {# snippet "spatial/snippets/spatial_query.html" , default_extent="[[47.55, -139.9], [59.8, -119.6]]" #}
+{% block secondary %}
+  <aside id="filters-panel" class="secondary span3">
+	{% block secondary_content %}
+	  {# snippet "spatial/snippets/spatial_query.html" , default_extent="[[47.55, -139.9], [59.8, -119.6]]" #}
 
-  {% for facet in c.facet_titles %}
-   {% set more_button = 'more-'+facet+'-button' %}
-  	{% if facet == 'type' %}
-  		{{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], label_function=h.edc_type_label, name=facet, more_button = more_button) }}
-  	{% else %}
-    	{{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, more_button = more_button) }}
-    {% endif %}
-  {% endfor %}
+	  {% for facet in c.facet_titles %}
+	   {% set more_button = 'more-'+facet+'-button' %}
+	  	{% if facet == 'type' %}
+	  		{{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], label_function=h.edc_type_label, name=facet, more_button = more_button, id=c.facet_titles[facet].lower() ) }}
+	  	{% else %}
+	    	{{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, more_button = more_button, id=c.facet_titles[facet].lower() ) }}
+	    {% endif %}
+	  {% endfor %}
 
-  {% block rss_feeds %}
-    {% snippet "package/snippets/rss_feeds.html" %}
-  {% endblock %}
+	  {% block rss_feeds %}
+	  	{{ h.snippet('package/snippets/rss_feeds.html', id='rss-feeds') }}
+	  {% endblock %}
 
-  {% block request_data %}
-    {% snippet "package/snippets/request_data.html" %}
-  {% endblock %}
-{% endblock %}
+	  {% block request_data %}
+	    {{ h.snippet('package/snippets/request_data.html', id='request-data') }}
+	  {% endblock %}
+	{% endblock %}
+  </aside>
+{% endblock secondary %}

--- a/ckanext/bcgov/templates/package/snippets/request_data.html
+++ b/ckanext/bcgov/templates/package/snippets/request_data.html
@@ -1,4 +1,4 @@
-<section class="module module-narrow module-shallow">
+<section id="{{ id }}" class="module module-narrow module-shallow">
     <h2 class="module-heading">Request Data</h2>
     <p class="module-content">Want more data?  Request data that you can use to build apps for B.C. citizens.  It has never been easier.</p>
     <p class="module-content"><a href="http://www.data.gov.bc.ca/dbc/catalogue/data_requests/request_data.page" title="Request Data" target="_blank">Click here to request data</a></p>

--- a/ckanext/bcgov/templates/package/snippets/rss_feeds.html
+++ b/ckanext/bcgov/templates/package/snippets/rss_feeds.html
@@ -1,4 +1,4 @@
-<section class="module module-narrow module-shallow">
+<section id="{{ id }}" class="module module-narrow module-shallow">
     <h2 class="module-heading"><i class="icon-medium icon-rss"></i> Subscribe & Stay Up To Date</h2>
     <ul class="unstyled nav nav-simple nav-facet">
         <li class="nav-item"><a href="{{ h.url_for(controller='ckanext.edc_rss.controllers.rss:RSSController', action='recent') }}" title="Subscribe to New data"><span>Subscribe to New data</span></a></li>

--- a/ckanext/bcgov/templates/snippets/facet_list.html
+++ b/ckanext/bcgov/templates/snippets/facet_list.html
@@ -2,17 +2,17 @@
   {% set hide_empty = hide_empty or false %}
   {% set selected_items = selected_items or h.get_facets_selected(name) %}
   {% set unselected_items = unselected_items or h.get_facets_unselected(name) %}
-  
+
   {% if selected_items or unselected_items or not hide_empty %}
-  
+
       {% if within_tertiary %}
         {% set nav_class = 'nav nav-pills nav-stacked' %}
         {% set nav_item_class = ' ' %}
         {% set wrapper_class = 'nav-facet nav-facet-tertiary' %}
       {% endif %}
-      
+
       {% block facet_list_item %}
-        <section class="{{ wrapper_class or 'module module-narrow module-shallow' }}">
+        <section id="{{ "%s %s"|format(id, "filter")|replace(' ','-') }}" class="{{ wrapper_class or 'module module-narrow module-shallow' }}">
           {% block facet_list_heading %}
             <h2 class="module-heading">
               <i class="icon-medium icon-filter"></i>
@@ -23,7 +23,7 @@
           {% block facet_list_items %}
   			{% set selected_items = selected_items or h.get_facets_selected(name) %}
   			{% set unselected_items = unselected_items or h.get_facets_unselected(name) %}
-  
+
           	{% if selected_items or unselected_items %}
             	<nav>
                 	<ul class="{{ nav_class or 'unstyled nav nav-simple nav-facet' }}">
@@ -57,7 +57,7 @@
                       		</li>
                 		{% endfor %}
                 	</ul>
-				</nav>          	
+				</nav>
                 	{% if unselected_items|length > 5 %}
                 		<a id="{{ more_button }}" class="facet-expand-collapse" >
                 			<div class="expander">
@@ -70,9 +70,9 @@
                 	{% endif %}
             {% else %}
             	<p class="module-content empty">{{ _('There are no {facet_type} that match this search').format(facet_type=title) }}</p>
-          	{% endif %}          
+          	{% endif %}
           {% endblock %}
         </section>
-      {% endblock %}  
+      {% endblock %}
   {% endif %}
 {% endblock %}

--- a/ckanext/bcgov/templates/snippets/search_form.html
+++ b/ckanext/bcgov/templates/snippets/search_form.html
@@ -29,7 +29,7 @@
     <div class="row row-fluid">
         {% if not no_title %}
             <div class="col-sm-6">
-                <h2>{% snippet 'snippets/search_result_text.html', query=query, count=count, type=type %}</h2>
+                <h2 id="record-count">{% snippet 'snippets/search_result_text.html', query=query, count=count, type=type %}</h2>
             </div>
         {% endif %}
   {% endblock %}
@@ -88,4 +88,3 @@
     <p><strong>There was an error while searching.</strong> Please try again.</p>
   {% endtrans %}
 {% endif %}
-


### PR DESCRIPTION
IDs have been added to the elements listed below:

//*[@id="content"]/div[3]/aside
https://cat.data.gov.bc.ca/dataset
On the homepage of the catalogue on the left hand side is a column with all the available search filters. I would like an id for this entire panel.
id = "filters-panel"

//*[@id="content"]/div[3]/aside/section[x] (x is between 1 and 7 inclusively.)
https://cat.data.gov.bc.ca/dataset
I would also like id's for each category of filter, i.e. License, Sectors, Dataset types,...(there's 7 excluding Request Data))
id = "licence-filter, sectors-filter, dataset-types-filter..."
The eighth one is "Request data", if that could just be called "request-data" that would be great.

//*[@id="form-dataset-search"]/div[2]/div[1]/h2
https://cat.data.gov.bc.ca/datasets
Another one for the dataset count displayed at the top, right under the search bar.
id = "record-count"

//*[@id="content"]/div[3]/div/section[1]/div[1]/div/a
https://cat.data.gov.bc.ca/datasets
The "Add Datasets" button at the top of the page above the search bar.
id = "add-datasets"

//*[@id="form-edc_dataset"]/div[2]/button
https://cat.data.gov.bc.ca/dataset/add
"Create Dataset" button
id = "create-dataset"