### PR TITLE
CITZEDC-854 - Modifications needed for header

### DIFF
--- a/ckanext/bcgov/fanstatic/edc_theme.css
+++ b/ckanext/bcgov/fanstatic/edc_theme.css
@@ -249,6 +249,10 @@ a.tag:hover{
   padding: 0 10px;
 }
 
+.site-title {
+    padding: 0 30px;
+}
+
 .share-this-record .dropdown-menu {
   border-top-color: transparent;
   margin-top: -1px;
@@ -288,6 +292,13 @@ li.select2-results-dept-0.select2-result.select2-result-unselectable.select2-dis
 li.select2-results-dept-0.select2-result.select2-result-selectable.select2-disabled {
 	display: none;
 }
+
+/* Don't display when in desktop/wider view */
+.account-container__mobile,
+#mobile-nav-list {
+  display: none;
+}
+
 /* Content */
 
 .module-content.page-header:first-child {
@@ -1233,6 +1244,47 @@ input.search.tt-hint {
 
 /* Phone only */
 @media (max-width: 767px) {
+  /* navigation bar */
+  nav#sub {
+    margin: 0 -20px;
+  }
+
+  #sub .navigationRibbon {
+    display: none;
+  }
+
+  .account-container__mobile {
+    padding: 12px 5px;
+  }
+
+  .account-container__mobile,
+  #mobile-nav-list {
+    display: block;
+  }
+
+  .account-container__mobile .account a {
+    display: inline-block;
+    width: 48%;
+    padding: 12px 20px;
+    text-align: center;
+  }
+  .account-container__mobile .account a:only-child,
+  .account-container__mobile .account a:last-child:nth-child(2n+1) {
+    width: 100%;
+  }
+
+  /* Hack for the list menu in mobile view because ul are getting in the way of clicking on links */
+  #header.collapsed-header #header-links > ul {
+    visibility: hidden;
+  }
+  #header.collapsed-header #header-links > ul > * {
+    visibility: visible;
+  }
+
+  /* breadcumb */
+  #wb-core #content .toolbar {
+    display: none;
+  }
 
   /* Content */
   .search-form .control-order-by {

--- a/ckanext/bcgov/templates/header.html
+++ b/ckanext/bcgov/templates/header.html
@@ -11,9 +11,8 @@
                 <div id="header-main-row1">
                     <div class="navbar-brand">
                         <a href="http://www2.gov.bc.ca/" class="logo">
-                            <img src="/assets/gov/images/gov3_bc_logo.png" class="hidden-xs">
-                            <img src="/assets/gov/images/gov3_bc_logo_mobile.png" class="visible-xs-inline-block">
-                            DataBC
+                            <img src="/assets/gov/images/gov3_bc_logo.png">
+                            <span class="hidden-xs">Data Catalogue</span>
                         </a>
                     </div>
                     <div class="navbar-header">
@@ -38,6 +37,8 @@
                 <div id="header-main-row2" class="collapse">
                     <div class="header-main-right">
                         <div id="header-links">
+                            {% snippet 'snippets/mobile-main-navigation.html', userobj=c.userobj %}
+
                             <ul class="inline nav navbar-nav">
                                 <li data-order="0"><a href="http://www2.gov.bc.ca/gov/content/governments/careers" target="_self">Careers</a></li>
                                 <li data-order="1"><a href="http://www2.gov.bc.ca/gov/content/home/services-a-z" target="_self">Services A-Z</a></li>
@@ -1150,7 +1151,11 @@
     </div>
 
     <nav id="sub">
-    {% snippet 'snippets/main-navigation.html', userobj=c.userobj %}
+        {% snippet 'snippets/main-navigation.html', userobj=c.userobj %}
+        
+        <div class="site-title visible-xs-inline-block">
+            <h1 class="">Data Catalogue</h1>
+        </div>
     </nav>
 
 {% endblock %}

--- a/ckanext/bcgov/templates/snippets/mobile-main-navigation.html
+++ b/ckanext/bcgov/templates/snippets/mobile-main-navigation.html
@@ -1,0 +1,69 @@
+<div class="account-container__mobile">
+    {% block header_account_container_content %}
+        {% if userobj %}
+            <div class="account avatar authed" data-module="me" data-me="{{ userobj.id }}">
+                {% block header_account_logged %}
+                    {% if userobj.sysadmin %}
+                        <a href="{{ h.url_for(controller='admin', action='index') }}" title="{{ _('Sysadmin settings') }}">
+                            Admin
+                        </a>
+                    {% endif %}
+
+                    <a href="{{ h.url_for(controller='user', action='read', id=userobj.name) }}" class="image" title="{{ _('View profile') }}">
+                        <span class="username">{{ userobj.display_name }}</span>
+                     </a>
+
+                    {% set new_activities = h.new_activities() %}
+
+                    {# <a class="notifications {% if new_activities > 0 %}notifications-important{% endif %}"> #}
+                    {% set notifications_tooltip = ngettext('Dashboard (%(num)d new item)', 'Dashboard (%(num)d new items)', new_activities) %}
+
+                    <a href="{{ h.url_for(controller='user', action='dashboard') }}" title="{{ notifications_tooltip }}">
+                        ({{ new_activities }}) Activities
+                    </a>
+                    {# </a> #}
+
+                    {# % block header_account_settings_link %}
+                        <a href="{{ h.url_for(controller='user', action='edit', id=userobj.name) }}" title="{{ _('Edit settings') }}">
+                        <i class="icon-cog"></i>
+                    </a>
+                    {% endblock % #}
+
+                    {% block header_account_log_out_link %}
+                        <a href="{{ h.url_for('/user/_logout') }}" title="{{ _('Log out') }}">
+                            Log out
+                        </a>
+                    {% endblock %}
+                {% endblock %}
+            </div>
+        {% else %}
+            <nav class="account not-authed">
+                {% block header_account_notlogged %}
+                    {% block header_account_notlogged_login %}
+                        {% if h.get_eas_login_url() %}
+                            <a href="{{ h.get_eas_login_url() }}">Log in</a>
+                        {% else %}
+                            <a href="{{ h.url_for('/user/login') }}">Log in</a>
+                        {% endif %}
+                    {% endblock %}
+                {% endblock %}
+            </nav>
+        {% endif %}
+    {% endblock %}
+</div>
+
+<ul id="mobile-nav-list" class="inline nav navbar-nav">
+    <li><a href="http://www2.gov.bc.ca/gov/content/governments/about-the-bc-government/databc">What is DataBC?</a></li>
+    <li><a href="{{ h.url('/dataset') }}" title="{{ g.site_title }} Home">Data Catalogue</a></li>
+    <li><a href="http://www2.gov.bc.ca/gov/content/governments/about-the-bc-government/databc/geographic-data-and-services">Geographic Services</a></li>
+    <li><a href="http://blog.data.gov.bc.ca/">Blog</a></li>
+    <li><a href="http://developer.gov.bc.ca/">Developers</a></li>
+    <li><a href="https://forms.gov.bc.ca/databc-contact-us/">Contact</a></li>
+    <li><a href="{{ h.url('/dataset') }}">Datasets</a></li>
+    <li><a href="{{ h.url('/organization') }}">Organizations</a></li>
+    <li><a href="{{ h.url('/groups') }}">Groups</a></li>
+    <li><a href="{{ h.url('/about') }}">About</a></li>
+    <li><a href="{{ h.url_for(controller='ckanext.edc_rss.controllers.rss:RSSController', action='recent') }}" title="Subscribe to New data"><span>Subscribe to New Data</span></a></li>
+    <li><a href="http://{{ h.disqus_get_forum_name() }}.disqus.com/latest.rss">Subscribe to Comments</a></li>
+    <li><a href="http://blog.data.gov.bc.ca/feed/" target="_blank">Subscribe to Blog Posts</a></li>
+</ul>


### PR DESCRIPTION
Changes:
  - only using the image with 'British Columbia' text for both mobile
  and regular view
  - 'DataBC' text in header changed to 'Data Catalogue'
  - In mobile view, breadcumb is now hidden
  - In mobile view, 'Data Catalogue' text moves out of the header and is
  displayed below the header
  - In mobile view, links in the navigation ribbon have are displayed in
  the hamburger menu instead of the main view