### PR TITLE
Issue #176 empty data lineage

### DIFF
--- a/ckanext/bcgov/templates/package/snippets/additional_info.html
+++ b/ckanext/bcgov/templates/package/snippets/additional_info.html
@@ -8,24 +8,21 @@
       </div>
       {% endif %}
 
-      {% if pkg.data_quality or pkg.lineage_statement %}
+      {% if pkg.type == "Geographic" or pkg.type == "Dataset" %}
         <table class="table dataset_view">
-          {% if pkg.data_quality %}
-              <tr>
-                  <td><strong>Data Quality</strong></td><td>{{ pkg.data_quality }}</td>
-              </tr>
-          {% endif %}
-          {% if pkg.lineage_statement %}
-              <tr>
-                  <td><strong>Lineage Statement</strong></td><td>{{ pkg.lineage_statement }}</td>
-              </tr>
-          {% endif %}
+          <tr>
+            <td><strong>Data Quality</strong></td><td>{{ pkg.data_quality }}</td>
+          </tr>
+
+          <tr>
+            <td><strong>Lineage Statement</strong></td><td>{{ pkg.lineage_statement }}</td>
+          </tr>
         </table>
       {% endif %}
     {% endblock %}
 
     {% block more_info_links %}
-        {% snippet "package/snippets/more_info_links.html", links=pkg.get('more_info',[]) %}
+      {% snippet "package/snippets/more_info_links.html", links=pkg.get('more_info',[]) %}
     {% endblock %}
 
     {# Displaying contact info #}
@@ -67,36 +64,34 @@
       {% snippet 'package/snippets/dates_view.html', pkg=pkg, last_modified = pkg.get('record_last_modified', '') %}
   {% endblock %}
 
-
   {% block package_resource_status %}
     {% if pkg.resource_status %}
-          <tr>
-              <td><strong>Resource Status</strong></td><td> {{ pkg.resource_status }} </td>
-          </tr>
-          {% if pkg.resource_status == _('historicalArchive')%}
-            {% if pkg.retention_expiry_date %}
-            <tr>
-                <td><strong>Retention Expiry Date </strong></td><td> {{ pkg.retention_expiry_date }} </td>
-            </tr>
-            {% endif %}
-            {% if pkg.source_data_path %}
-            <tr>
-                <td><strong>Source Data Path </strong></td><td> {{ pkg.source_data_path }} </td>
-            </tr>
-            {% endif %}
-          {% endif %}
+      <tr>
+        <td><strong>Resource Status</strong></td><td> {{ pkg.resource_status }} </td>
+      </tr>
+      {% if pkg.resource_status == _('historicalArchive')%}
+        {% if pkg.retention_expiry_date %}
+        <tr>
+          <td><strong>Retention Expiry Date </strong></td><td> {{ pkg.retention_expiry_date }} </td>
+        </tr>
+        {% endif %}
+        {% if pkg.source_data_path %}
+        <tr>
+          <td><strong>Source Data Path </strong></td><td> {{ pkg.source_data_path }} </td>
+        </tr>
+        {% endif %}
       {% endif %}
-      {% if pkg.replacement_record %}
-          <tr>
-              <td><strong>Replacement Record</strong></td><td><a href="{{ pkg.replacement_record }}">{{ pkg.replacement_record }}</a></td>
-          </tr>
-      {% endif %}
+    {% endif %}
+    {% if pkg.replacement_record %}
+        <tr>
+          <td><strong>Replacement Record</strong></td><td><a href="{{ pkg.replacement_record }}">{{ pkg.replacement_record }}</a></td>
+        </tr>
+    {% endif %}
   {% endblock %}
 
   {% block package_extra_info %}
-      {% snippet "package/snippets/pkg_extra_info.html", pkg=pkg %}
+    {% snippet "package/snippets/pkg_extra_info.html", pkg=pkg %}
   {% endblock %}
 
   </table>
-
 </div>

--- a/ckanext/bcgov/templates/package/snippets/pkg_extra_info.html
+++ b/ckanext/bcgov/templates/package/snippets/pkg_extra_info.html
@@ -19,21 +19,4 @@
             <td><strong>Metadata Standard Version</strong></td><td>{{ pkg.metadata_standard_version }}</td>
         </tr>
     {% endif %}
-    <tr>
-        <td><strong>Data Quality</strong></td><td>{{ pkg.data_quality }}</td>
-    </tr>
-    <tr>
-        <td><strong>Lineage Statement</strong></td><td>{{ pkg.lineage_statement }}</td>
-    </tr>
-{% else %}
-    {% if pkg.data_quality %}
-        <tr>
-            <td><strong>Data Quality</strong></td><td>{{ pkg.data_quality }}</td>
-        </tr>
-    {% endif %}
-    {% if pkg.lineage_statement %}
-        <tr>
-            <td><strong>Lineage Statement</strong></td><td>{{ pkg.lineage_statement }}</td>
-        </tr>
-    {% endif %}
 {% endif %}


### PR DESCRIPTION
Data Quality and Lineage Statements are always visible on Geographic and Dataset. Also Data and Lineage are remove from pkg_extra_info template and won't show on Application and Service package types.