### PR TITLE
Reverting back to format name instead of id for resource metadata, plus other fixes

### DIFF
--- a/ckanext/bcgov/controllers/ofi.py
+++ b/ckanext/bcgov/controllers/ofi.py
@@ -100,7 +100,7 @@ class EDCOfiController(ApiController):
 
             return self._finish_ok(max_aoi)
 
-        elif call_action == 'create_aoi':
+        elif call_action == 'ofi_create_order':
             data.update({'aoi_params': query_params})
             return self._finish_ok(action_func(context, data))
 

--- a/ckanext/bcgov/fanstatic/edc_mow.js
+++ b/ckanext/bcgov/fanstatic/edc_mow.js
@@ -91,8 +91,7 @@ this.ckan.module('edc_mow', function($, _) {
       self.aoi = latLonList;
       var areaM2 = L.GeometryUtil.geodesicArea(latLonList)
       var areaHect = Math.round(areaM2 * 0.0001);
-      console.log(areaM2);
-      console.log(areaHect);
+
       $('#selected-area').html(_formatNum(areaHect))
 
       if (areaHect < _maxAreaHectares || _maxAreaHectares == 0) {
@@ -135,11 +134,17 @@ this.ckan.module('edc_mow', function($, _) {
         modal_controls.append('<button id="order-btn" class="btn btn-primary">Place order</button>');
       }
 
-      $("#consent-check").change(function() {
+      var consent_check = $("#consent-check");
+
+      if (consent_check.prop('checked')) {
+        $("#consent-terms").hide()
+      }
+
+      consent_check.change(function() {
         if (this.checked) 
-          $("#consent-terms").css("display", "none");
+          $("#consent-terms").hide();
         else
-          $("#consent-terms").css("display", "block");
+          $("#consent-terms").show();
       });
       _fetchMaxDownloadableArea(_initSuccess, _initFailed);
     };
@@ -169,18 +174,55 @@ this.ckan.module('edc_mow', function($, _) {
       return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
     };
 
+    var _checkForm = function() {
+      var form_check = true;
+
+
+
+
+      var error_html = '';
+
+      var consent = $("#consent-check").prop('checked');
+      if (!consent) {
+        error_html += '<div><strong>Error:</strong> You must accept the term and conditions.</div>';
+
+        $("#consent").addClass('error error-missing');
+
+        form_check = false;
+      } else {
+        $("#consent").removeClass('error error-missing');
+      }
+
+      var email = $.trim($('#email1').val());
+      if (email === '') {
+        error_html += '<div><strong>Error:</strong> Please provide an email address.</div>';
+
+        $("#email").addClass('error error-missing');
+
+        form_check = false;
+      } else {
+        $("#email").removeClass('error error-missing');
+      }
+
+      if (!form_check) {
+        $('#mow-err').html(error_html).show();
+      }
+
+      return form_check;
+    };
+
     var _placeOrder = function() {
       _toggleSpinner(true);
 
-      for (var key in self.aoi) {
-          console.log('LAT: ' + self.aoi[key].lat);
-          console.log('LNG: ' + self.aoi[key].lng);
+      if (_checkForm() == false) {
+        _toggleSpinner(false);
+        return false;
       }
 
       var aoi_data = {
         'object_name': self.options.object_name,
         'aoi': self.aoi,
-        'emailAddress': aoi_form.find('#email1').val(),
+        'emailAddress': $.trim(aoi_form.find('#email1').val()),
         'EPSG': aoi_form.find('#map_projection').val(),
         'format': format,
         'featureItems': [

--- a/ckanext/bcgov/fanstatic/edc_mow.js
+++ b/ckanext/bcgov/fanstatic/edc_mow.js
@@ -10,7 +10,7 @@
 "use strict";
 
 this.ckan.module('edc_mow', function($, _) {
-    var self, modal, modal_subtitle, content_body, modal_controls, spinner, aoi_form, format_type;
+    var self, modal, modal_subtitle, content_body, modal_controls, spinner, aoi_form, format;
 
     var _map = null;
     var _maxAreaHectares = null;
@@ -130,6 +130,11 @@ this.ckan.module('edc_mow', function($, _) {
     var _initStart = function() {
       $("#mow-ready").hide();
       $("#mow-err").hide();
+
+      if (!document.getElementById("order-btn")) {
+        modal_controls.append('<button id="order-btn" class="btn btn-primary">Place order</button>');
+      }
+
       $("#consent-check").change(function() {
         if (this.checked) 
           $("#consent-terms").css("display", "none");
@@ -165,6 +170,8 @@ this.ckan.module('edc_mow', function($, _) {
     };
 
     var _placeOrder = function() {
+      _toggleSpinner(true);
+
       for (var key in self.aoi) {
           console.log('LAT: ' + self.aoi[key].lat);
           console.log('LNG: ' + self.aoi[key].lng);
@@ -175,7 +182,7 @@ this.ckan.module('edc_mow', function($, _) {
         'aoi': self.aoi,
         'emailAddress': aoi_form.find('#email1').val(),
         'EPSG': aoi_form.find('#map_projection').val(),
-        'formatType': format_type,
+        'format': format,
         'featureItems': [
           {'featureItem': self.options.object_name}
         ]          
@@ -205,9 +212,11 @@ this.ckan.module('edc_mow', function($, _) {
             modal_controls.find('#order-btn').remove();
           }
 
+          _toggleSpinner(false);
         },
         'error': function(jqXHR, textStatus, errorThrown) {
           console.log(jqXHR.responseText);
+          _toggleSpinner(false);
         }
       });
      };
@@ -229,7 +238,7 @@ this.ckan.module('edc_mow', function($, _) {
               $(button).on('click', function(event) {
                 // allows the button for the specified resource to give its format type to be passed to the server
                 event.preventDefault();
-                format_type = event.target.id;                
+                format = event.target.id;
                 $("#edc-mow").modal("show");
               });
             });

--- a/ckanext/bcgov/fanstatic/edc_mow_style.css
+++ b/ckanext/bcgov/fanstatic/edc_mow_style.css
@@ -31,3 +31,9 @@
 #edc-mow #loading .add-data-loader {
 	bottom: calc(50% - 10em);
 }
+#edc-mow #consent .checkbox {
+	padding-left: 35px;
+}
+#edc-mow #consent #consent-terms {
+	padding-left: 15px;
+}

--- a/ckanext/bcgov/logic/auth/ofi/call_action.py
+++ b/ckanext/bcgov/logic/auth/ofi/call_action.py
@@ -80,7 +80,7 @@ def get_max_aoi(context, data_dict=None):
     return {'success': False, 'msg': _('Failed authorization.')}
 
 
-def create_aoi(context, data_dict=None):
+def create_order(context, data_dict=None):
     user_obj = context.get('auth_user_obj')
     user_obj_checked = context.get('__auth_user_obj_checked', False)
 

--- a/ckanext/bcgov/logic/ofi/call_action.py
+++ b/ckanext/bcgov/logic/ofi/call_action.py
@@ -350,7 +350,7 @@ def get_max_aoi(context, ofi_vars, ofi_resp):
 
 
 @ofi_logic.setup_ofi_action()
-def create_aoi(context, ofi_vars, ofi_resp):
+def create_order(context, ofi_vars, ofi_resp):
     from string import Template
 
     results = {}

--- a/ckanext/bcgov/logic/ofi/call_action.py
+++ b/ckanext/bcgov/logic/ofi/call_action.py
@@ -353,8 +353,6 @@ def get_max_aoi(context, ofi_vars, ofi_resp):
 def create_aoi(context, ofi_vars, ofi_resp):
     from string import Template
 
-    file_formats = toolkit.get_action('file_formats')({}, {})
-
     results = {}
 
     aoi_data = ofi_vars.get('aoi_params', {})
@@ -380,7 +378,7 @@ def create_aoi(context, ofi_vars, ofi_resp):
         u'aoi': aoi_xml,
         u'emailAddress': aoi_data.get(u'emailAddress'),
         u'featureItems': aoi_data.get(u'featureItems'),
-        u'formatType': aoi_data.get(u'format'),
+        u'formatType': _get_format_id(aoi_data.get(u'format')),
         u'useAOIBounds': u'0',
         u'aoiType': u'1',
         u'clippingMethodType': u'0',
@@ -405,3 +403,15 @@ def create_aoi(context, ofi_vars, ofi_resp):
         })
 
     return results
+
+
+def _get_format_id(format_name):
+    file_formats = toolkit.get_action('file_formats')({}, {})
+
+    format_id = None
+
+    for file_format in file_formats:
+        if file_format[u'formatname'] == format_name:
+            format_id = str(file_format[u'formatID'])
+
+    return format_id

--- a/ckanext/bcgov/plugin.py
+++ b/ckanext/bcgov/plugin.py
@@ -363,7 +363,7 @@ class SchemaPlugin(plugins.SingletonPlugin):
             'remove_ofi_resources': ofi.remove_ofi_resources,
             'edit_ofi_resources': ofi.edit_ofi_resources,
             'get_max_aoi': ofi.get_max_aoi,
-            'create_aoi': ofi.create_aoi
+            'ofi_create_order': ofi.create_order
         }
 
     def get_auth_functions(self):
@@ -378,7 +378,7 @@ class SchemaPlugin(plugins.SingletonPlugin):
             'remove_ofi_resources': ofi.remove_ofi_resources,
             'edit_ofi_resources': ofi.edit_ofi_resources,
             'get_max_aoi': ofi.get_max_aoi,
-            'create_aoi': ofi.create_aoi
+            'ofi_create_order': ofi.create_order
         }
 
 

--- a/ckanext/bcgov/templates/snippets/edc_mow.html
+++ b/ckanext/bcgov/templates/snippets/edc_mow.html
@@ -3,7 +3,7 @@
   data-module-object_name="{{ pkg_obj_name or false }}"
   data-module-package_id="{{ pkg_id }}"
   data-module-mow_max_aoi_url="{{ h.url_for('ofi api', call_action='get_max_aoi') }}"
-  data-module-aoi_create_order_url="{{ h.url_for('ofi api', call_action='create_aoi') }}"
+  data-module-aoi_create_order_url="{{ h.url_for('ofi api', call_action='ofi_create_order') }}"
   style="width: 800px; margin-left: -400px;"
 >
 

--- a/ckanext/bcgov/templates/snippets/edc_mow.html
+++ b/ckanext/bcgov/templates/snippets/edc_mow.html
@@ -17,7 +17,10 @@
 
     <div class="modal-body" style="min-height: 460px;">
         <div id="mow-content">
-        
+          <div id="mow-err" class="alert alert-error" style="display: none">
+            <strong>Error:</strong> Unable to determine the maximum downloadable area for this dataset.
+          </div>
+
           <div id="mow-ready" style="display: none">
           <table width="100%">
           <tr>
@@ -33,7 +36,7 @@
               Please check the <a href="https://catalogue.data.gov.bc.ca/dataset/2ebb35d8-c82f-4a17-9c96-612ac3532d55">catalogue record</a> for an alternative provincial file / resource for download.
             </p-->
           
-            <form id="aoi-order-form" style="padding-left: 10px;">
+            <form id="aoi-order-form" style="padding-left: 10px;" class="form-horizontal">
 
               <div id="area-info">
                 <p><strong>Maximum download area for this dataset:</strong> <span class="max-area-hectares"></span> hectares</p>
@@ -45,30 +48,41 @@
                 </div>
               </div>
 
-              <label for="epsg">
-                Map projection:
-                <select name="EPSG" id="map_projection">
-                  <option value="1" >BC Albers NAD 83 m</a></option>
-                  <option value="2" >Geographic WGS 84 Long / Lat dd</option>
-                  <option value="3" >UTM Zone 7 m</option>
-                  <option value="4" >UTM Zone 8 m</option>
-                  <option value="5" >UTM Zone 9 m</option>
-                  <option value="6" >UTM Zone 10 m</option>
-                  <option value="7" >UTM Zone 11 m</option>
-                </select>
-              </label>
-
-              <div class="checkbox">
-                <p><input id="consent-check" type="checkbox"/>I consent to the collection of my email address as per the terms.</p>
+              <div id="map-proj" class="control-group">
+                <label for="map_projection" class="control-label">Map projection:</label>
+                <div class="controls">
+                  <select name="EPSG" id="map_projection">
+                    <option value="1" >BC Albers NAD 83 m</a></option>
+                    <option value="2" >Geographic WGS 84 Long / Lat dd</option>
+                    <option value="3" >UTM Zone 7 m</option>
+                    <option value="4" >UTM Zone 8 m</option>
+                    <option value="5" >UTM Zone 9 m</option>
+                    <option value="6" >UTM Zone 10 m</option>
+                    <option value="7" >UTM Zone 11 m</option>
+                  </select>
+                </div>
               </div>
 
-              <div>
-                <p id="consent-terms"><small>
+              <div id="consent" class="control-group">
+
+                <label class="checkbox">
+                  <input id="consent-check" type="checkbox" />
+                  I consent to the collection of my email address as per the terms.
+                </label>
+
+                <p id="consent-terms">
+                  <small>
                  The information on this form is collected under the authority of Sections 26(c) and 27(1)(c) of the Freedom of Information and Protection of Privacy Act [RSBC 1996 c.165], and will help us to assess and respond to your enquiry.
                  By consenting to submit this form you are confirming that you are authorized to provide information of individuals/organizations/businesses for the purpose of your enquiry.
-                </small></p>
+                  </small>
+                </p>
+              </div>
 
-                <label for="email-ofi">Email address: <input type="email" class="form-control" id="email1" autocomplete="off"></label>
+              <div id="email" class="control-group">
+                <label for="email1" class="control-label">Email address:</label>
+                <div class="controls">
+                  <input type="email" class="form-control" id="email1" autocomplete="on" />
+                </div>
               </div>
 
             </form>
@@ -77,11 +91,6 @@
           </tr>
           </table>
           </div>
-
-          <div id="mow-err" class="alert alert-error" style="display: none">
-            <strong>Error:</strong> Unable to determine the maximum downloadable area for this dataset.
-          </div>
-
         </div>
     </div>
 


### PR DESCRIPTION
mow now requires email and consent

ofi manage edit ofi resources should be working again

create_aoi refactored to ofi_create_order