### PR TITLE
Issue 300 - Fixing access denied error for users placing an order

### DIFF
--- a/ckanext/bcgov/logic/auth/ofi/call_action.py
+++ b/ckanext/bcgov/logic/auth/ofi/call_action.py
@@ -73,6 +73,6 @@ def ofi_create_order(context, data_dict=None):
     return {'success': True}
 
 
-@toolkit.auth_allow-anonymous_access
+@toolkit.auth_allow_anonymous_access
 def file_formats(context, data_dict=None):
     return {'success': True}

--- a/ckanext/bcgov/logic/auth/ofi/call_action.py
+++ b/ckanext/bcgov/logic/auth/ofi/call_action.py
@@ -5,20 +5,6 @@ import ckan.plugins.toolkit as toolkit
 _ = toolkit._
 
 
-def file_formats(context, data_dict=None):
-    '''
-    No checks for annonymous and sysadmin users because core ckan
-    already does that before calling this function
-    '''
-    user_obj = context.get('auth_user_obj')
-    user_obj_checked = context.get('__auth_user_obj_checked', False)
-
-    if user_obj and user_obj_checked:
-        return {'success': True}
-
-    return {'success': False, 'msg': _('Failed authorization.')}
-
-
 def geo_resource_form(context, data_dict=None):
     user_obj = context.get('auth_user_obj')
     user_obj_checked = context.get('__auth_user_obj_checked', False)
@@ -84,4 +70,9 @@ def get_max_aoi(context, data_dict=None):
 
 @toolkit.auth_allow_anonymous_access
 def ofi_create_order(context, data_dict=None):
+    return {'success': True}
+
+
+@toolkit.auth_allow-anonymous_access
+def file_formats(context, data_dict=None):
     return {'success': True}


### PR DESCRIPTION
Issue #300 
file_formats action now allows for authorizing anonymous users to make the /info/fileFormats DWDS api call through bcgov ckan