### PR TITLE
Issue #311 & #312 - Updating populate_dataset_with_ofi for bulk update use

### DIFF
--- a/ckanext/bcgov/controllers/package.py
+++ b/ckanext/bcgov/controllers/package.py
@@ -601,7 +601,7 @@ def _setup_ofi(id, context=None, pkg_dict=None, open_modal=True):
         if len(ofi_resources) > 0:
             projections = get_action(u'crs_types')(context, {})
             ofi_data.update({
-                u'object_name': pkg_dict[u'object_name'],
+                u'object_name': pkg_dict.get(u'object_name', ""),
                 u'ofi_resources': ofi_resources,
                 u'ofi_exists': True,
                 u'secure': True,

--- a/ckanext/bcgov/fanstatic/edc_mow.js
+++ b/ckanext/bcgov/fanstatic/edc_mow.js
@@ -28,8 +28,10 @@ this.ckan.module('edc_mow', function($, _) {
       $.ajax({
         'url': self.options.mow_max_aoi_url,
         'data': {
+          // the ckan js module has some issues with empty values when
+          //  getting vars from the DOM (data-* attr), they are assigned to true in js
           'secure': (self.options.secure_call !== 'False' ? true : false),
-          'object_name': self.options.object_name,
+          'object_name': (self.options.object_name !== 'False' ? self.options.object_name : false),
           'package_id': self.options.package_id
         },
         'success': function(data, status) {

--- a/ckanext/bcgov/fanstatic/ofi/ofi_modal.js
+++ b/ckanext/bcgov/fanstatic/ofi/ofi_modal.js
@@ -25,10 +25,6 @@ this.ckan.module('ofi_modal', function($, _) {
       ofi_form = this.$('#ofi-lookup-form');
       modal_controls = this.$('.modal-footer');
 
-      if (this.options.object_name == 'False') {
-        return;
-      }
-
       console.log(this.options);
 
       var open_modal = this.options.ofi_results.open_modal;
@@ -45,6 +41,7 @@ this.ckan.module('ofi_modal', function($, _) {
         modal_controls.find('#ofi-delete').on('click', this._removeOFIResources);
         modal_controls.find('#ofi-edit').on('click', this._editOFIResources);
       } else {
+        modal_controls.find('#ofi-force-confirm').on('click',this._getResourceForm);
         this._showResults(content);
       }
 
@@ -55,6 +52,8 @@ this.ckan.module('ofi_modal', function($, _) {
     _getResourceForm: function(event) {
       event.preventDefault();
       self._toggleSpinner(true);
+
+      self.options.force_confirm = (event.target.id == 'ofi-force-confirm');
 
       $.ajax({
         'url': self.options.ofi_geo_resource_form_url,
@@ -69,7 +68,7 @@ this.ckan.module('ofi_modal', function($, _) {
           self._showResults(data);
           modal_subtitle.text('Add OFI Resources');
 
-          modal_controls.find('#ofi-confirm')
+          modal_controls.find('#ofi-confirm, #ofi-force-confirm')
             .off('click', self._getResourceForm)
             .on('click', self._createResources)
             .text('Save');
@@ -95,6 +94,7 @@ this.ckan.module('ofi_modal', function($, _) {
           'package_id': self.options.package_id,
           'object_name': self.options.object_name,
           'secure': true,
+          'force_populate': self.options.force_confirm || false,
           'ofi_resource_info': form_as_obj
         }),
         'contentType': 'application/json; charset=utf-8',
@@ -104,7 +104,7 @@ this.ckan.module('ofi_modal', function($, _) {
           modal_controls.find('#ofi-cancel')
             .remove();
 
-          modal_controls.find('#ofi-confirm')
+          modal_controls.find('#ofi-confirm, #ofi-force-confirm')
             .off('click', self._createResources)
             .text('Finish')
             .on('click', self._redirectToDatasetPage);
@@ -266,8 +266,8 @@ this.ckan.module('ofi_modal', function($, _) {
           .text('Edit')
           .on('click', self._editOFIResources);
       }
-      else if (modal_controls.has('#ofi-confirm').length) {
-        modal_controls.find('#ofi-confirm')
+      else if (modal_controls.has('#ofi-confirm, #ofi-force-confirm').length) {
+        modal_controls.find('#ofi-confirm, #ofi-force-confirm')
           .off('click', self._redirectToDatasetPage)
           .text('Edit')
           .prop('id', 'ofi-edit')

--- a/ckanext/bcgov/logic/ofi/__init__.py
+++ b/ckanext/bcgov/logic/ofi/__init__.py
@@ -82,7 +82,7 @@ def setup_ofi_action(api_url=None):
 
                 # expecting additonal pathing if incoming api endpoint ends with a '/'
                 if api_url.endswith(u'/'):
-                    if 'object_name' in data:
+                    if 'object_name' in data and data[u'object_name']:
                         url += data[u'object_name']
 
                 data[u'api_url'] = url

--- a/ckanext/bcgov/templates/ofi/ofi_modal.html
+++ b/ckanext/bcgov/templates/ofi/ofi_modal.html
@@ -38,7 +38,8 @@
                 {% if ofi['ofi_exists'] %}
                     <div>OFI Resources are present in this dataset.</div>
                 {% elif pkg_obj_name == '' %}
-                    <div>No 'Object Name' exists for this dataset. Add an 'Object Name' to the dataset, for OFI.</div>
+                    <h4 style="text-align:center;">No 'Object Name' exists for this dataset.</h4>
+                    <h4 style="text-align:center;">Would you like to create the resources anyways?</h4>
                 {% else %}
                     {% set content = ofi['content'] or false %}
                     {% if content['allowed'] %}
@@ -56,7 +57,9 @@
         {% if ofi['ofi_exists'] %}
             <button id="ofi-delete" class="btn btn-danger pull-left">Delete</button>
             <button id="ofi-edit" class="btn btn-primary">Edit</button>
-        {% elif pkg_obj_name != '' %}
+        {% elif pkg_obj_name == '' %}
+            <button id="ofi-force-confirm" class="btn btn-primary">Yes</button>
+        {% else %}
             {% set content = ofi['content'] or false %}
             {% if content['allowed'] %}
                 <button id="ofi-confirm" class="btn btn-primary">Yes</button>


### PR DESCRIPTION
Issues #311 #312 

WIP, needs some testing cad.

This PR include several changes that ended up crossing between the 2 tickets. 

First off, `populate_dataset_with_ofi` action function had some issues with api calls, but should now be in a state for bulk update. `/api/action` or `/api/ofi` urls can be used to `POST` to `populate_dataset_with_ofi`. There is one caveat to using the `/api/ofi` endpoint; You must include `Accept: application/json` in your request header to get a usable response, otherwise html will be in the response body.

`populate_dataset_with_ofi` can now deal with no object name set in the dataset. This PR also includes front-end changes to accommodate for no set object name.
When trying to `populate_dataset_with_ofi` via api on a dataset with no object name, `force_populate` needs to be `true` in the body of the `POST` request.

There are some parts that need to be tested in cad due to local env having issues with the way secure calls work.
