### PR TITLE
Issue #312 - Save Dataset without adding resources

### DIFF
--- a/ckanext/bcgov/plugin.py
+++ b/ckanext/bcgov/plugin.py
@@ -134,8 +134,10 @@ class SchemaPlugin(plugins.SingletonPlugin):
         with SubMapper(map, controller=package_controller) as m:
             m.connect('/dataset/add', action='typeSelect')
             m.connect('add dataset', '/dataset/new', action='new')
+            m.connect('add dataset type', '/{dataset_type}/new', action='new')
             m.connect('search', '/dataset', action='search', highlight_actions='index search')
             m.connect('dataset_read', '/dataset/{id}', action='read', ckan_icon='sitemap')
+            m.connect('dataset type read', '/{dataset_type}/{id}', action='read', ckan_icon='sitemap')
             m.connect('duplicate', '/dataset/duplicate/{id}/{package_type}', action='duplicate')
             m.connect('/dataset/{id}/resource/{resource_id}', action='resource_read')
             m.connect('/dataset/{id}/resource_delete/{resource_id}', action='resource_delete')
@@ -226,7 +228,7 @@ class SchemaPlugin(plugins.SingletonPlugin):
         return map
 
     def after_map(self, map):
-        return map;
+        return map
 
     def before_index(self, pkg_dict):
         '''

--- a/ckanext/bcgov/templates/ofi/ofi_modal.html
+++ b/ckanext/bcgov/templates/ofi/ofi_modal.html
@@ -38,8 +38,9 @@
                 {% if ofi['ofi_exists'] %}
                     <div>OFI Resources are present in this dataset.</div>
                 {% elif pkg_obj_name == '' %}
-                    <h4 style="text-align:center;">No 'Object Name' exists for this dataset.</h4>
-                    <h4 style="text-align:center;">Would you like to create the resources anyways?</h4>
+                    <div>No 'Object Name' exists for this dataset. Add an 'Object Name' to the dataset, for OFI.</div>
+                    {#<h4 style="text-align:center;">No 'Object Name' exists for this dataset.</h4>#}
+                    {#<h4 style="text-align:center;">Would you like to create the resources anyways?</h4>#}
                 {% else %}
                     {% set content = ofi['content'] or false %}
                     {% if content['allowed'] %}
@@ -57,9 +58,10 @@
         {% if ofi['ofi_exists'] %}
             <button id="ofi-delete" class="btn btn-danger pull-left">Delete</button>
             <button id="ofi-edit" class="btn btn-primary">Edit</button>
-        {% elif pkg_obj_name == '' %}
+        {#{% elif pkg_obj_name == '' %}
             <button id="ofi-force-confirm" class="btn btn-primary">Yes</button>
-        {% else %}
+        {% else %}#}
+        {% elif pkg_obj_name != '' %}
             {% set content = ofi['content'] or false %}
             {% if content['allowed'] %}
                 <button id="ofi-confirm" class="btn btn-primary">Yes</button>

--- a/ckanext/bcgov/templates/package/snippets/package_form.html
+++ b/ckanext/bcgov/templates/package/snippets/package_form.html
@@ -141,6 +141,7 @@ then itself be extended to add/remove blocks of functionality. #}
           {% endif %}
         {% endif %}
       {% endblock %}
+      <button id="finish" class="btn" type="submit" name="save" value="finish">{{ _('Save Dataset') }}</button>
       <button class="btn btn-primary" type="submit" name="save" id="save2" onclick="this.style.visibility = 'hidden';document.getElementById('save2').style.visibility='hidden';">{% block save_button_text %}{{ _('Next: Add Data') }}{% endblock %}</button>
     </div>
   {% endblock %}

--- a/ckanext/bcgov/templates/package/snippets/resource_form.html
+++ b/ckanext/bcgov/templates/package/snippets/resource_form.html
@@ -35,7 +35,7 @@
     {# OFI modal button #}
     <div class="control-group">
       <div class="controls">
-        <a href="#ofi-results" role="button" class="btn btn-primary" data-toggle="modal">Manage OFI Resources</a>
+        <a href="#ofi-results" role="button" class="btn btn-primary" data-toggle="modal">Manage DWDS Resources</a>
       </div>
     </div>
   {% endif %}


### PR DESCRIPTION
Issue #312 

This PR had to include overriding ckan's route for creating a new dataset. Extensive testing should be done with all dataset types. 

The behaviour should be exactly the same when creating a dataset.
The only difference is that clicking on the 'Save Dataset' button should redirect to the new dataset read page if successful. 

Any errors that may occur when submitting by the 'Save Dataset' or 'Next: Add Data' buttons, should also be the same as before.