### PR TITLE
fix markdown rendering

### DIFF
--- a/ckanext/bcgov/templates/package/snippets/additional_info.html
+++ b/ckanext/bcgov/templates/package/snippets/additional_info.html
@@ -4,7 +4,7 @@
       {% if pkg.purpose %}
       <h2>Purpose</h2>
       <div id="purpose">
-        {{ pkg.purpose }}
+        {{ h.render_markdown(pkg.purpose) }}
       </div>
       {% endif %}
 


### PR DESCRIPTION
Part of the ckanext was not calling render_markdown() so markdown was not being rendered in the **Purpose** section