### PR TITLE
Issue #313 - Sent aoiType for non-spatial province-wide orders

### DIFF
--- a/ckanext/bcgov/fanstatic/edc_mow.js
+++ b/ckanext/bcgov/fanstatic/edc_mow.js
@@ -76,7 +76,7 @@ this.ckan.module('edc_mow', function($, _) {
     };
 
     var _mapViewChanged = function(e) {
-      if (e.type === 'zoomend' && e.target.getZoom() == 4) {
+      if (e.target.getZoom() == 4) {
         var latLonList = [];
       }
       else {

--- a/ckanext/bcgov/fanstatic/edc_mow.js
+++ b/ckanext/bcgov/fanstatic/edc_mow.js
@@ -76,13 +76,18 @@ this.ckan.module('edc_mow', function($, _) {
     };
 
     var _mapViewChanged = function(e) {
-      var bounds = _map.getBounds();
-      var latLonList = [
-        bounds.getSouthWest(),
-        bounds.getNorthWest(),
-        bounds.getNorthEast(),
-        bounds.getSouthEast(),
-        bounds.getSouthWest()]
+      if (e.type === 'zoomend' && e.target.getZoom() == 4) {
+        var latLonList = [];
+      }
+      else {
+        var bounds = _map.getBounds();
+        var latLonList = [
+          bounds.getSouthWest(),
+          bounds.getNorthWest(),
+          bounds.getNorthEast(),
+          bounds.getSouthEast(),
+          bounds.getSouthWest()];
+      }
 
       self.aoi = latLonList;
       var areaM2 = L.GeometryUtil.geodesicArea(latLonList)


### PR DESCRIPTION
If a user is zoomed all the way out of the map in the modal, and then places an order, aoiType is specified to be non-spatial and no aoi document of coordinates are sent for the order.