### PR TITLE
Issue #336 - stop external non-datastore previews from displaying

### DIFF
--- a/ckanext/bcgov/templates/package/resource_read.html
+++ b/ckanext/bcgov/templates/package/resource_read.html
@@ -91,15 +91,18 @@
           </div>
         {% endblock %}
       </div>
-      {# CITZEDC769 - xls/xlsx previews not being identified
+      {# Issue #336 - If the resources is not using the datastore, dont render the preview #}
+      {% if (res.size != '0' or res.datastore_active == True) %}
+        {# CITZEDC769 - xls/xlsx previews not being identified
             Solution for now is to check the resource type for xls/xlsx and don't
             display the preview element at all, data preview doesn't have any option
             to prevent the preview automatically display for specific types
-       #}
-      {% if not (res.format == 'xlsx' or res.format == 'xls') %}
-        {% block data_preview %}
-            {{ super() }}
-        {% endblock %}
+        #}
+        {% if not (res.format == 'xlsx' or res.format == 'xls') %}
+          {% block data_preview %}
+              {{ super() }}
+          {% endblock %}
+        {% endif %}
       {% endif %}
     </section>
   {% endblock %}


### PR DESCRIPTION
Issue #336 

In templates, only render the resource preview if datastore is enabled on the resource or isn't external.