### PR TITLE
A better solution to the Filter Query issue

### DIFF
--- a/ckanext/bcgov/plugin.py
+++ b/ckanext/bcgov/plugin.py
@@ -333,7 +333,7 @@ class SchemaPlugin(plugins.SingletonPlugin):
                     if not fq:
                         fq += ' +(edc_state:("PUBLISHED" OR "PENDING ARCHIVE") AND metadata_visibility:("Public"))'
                     else:
-                        fq += ' AND +(edc_state:("PUBLISHED" OR "PENDING ARCHIVE") AND metadata_visibility:("Public"))'
+                        fq = 'q.op=AND&' + fq + ' +(edc_state:("PUBLISHED" OR "PENDING ARCHIVE") AND metadata_visibility:("Public"))'
 
         except Exception:
             if 'fq' in search_params:

--- a/ckanext/bcgov/plugin.py
+++ b/ckanext/bcgov/plugin.py
@@ -328,12 +328,14 @@ class SchemaPlugin(plugins.SingletonPlugin):
                                 fq += ' OR ' + 'owner_org:(' + ' OR '.join(user_orgs) + ')'
 
                         fq += ')'
-                #Public user can only view public and published records
+
                 else:
-                    if not fq:
-                        fq += ' +(edc_state:("PUBLISHED" OR "PENDING ARCHIVE") AND metadata_visibility:("Public"))'
-                    else:
-                        fq = 'q.op=AND&' + fq + ' +(edc_state:("PUBLISHED" OR "PENDING ARCHIVE") AND metadata_visibility:("Public"))'
+                    if fq:
+                        # Set the filter query default Operator to AND
+                        search_params['q'] += '&q.op=AND&'
+
+                    # Public user can only view public and published records
+                    fq += ' +(edc_state:("PUBLISHED" OR "PENDING ARCHIVE") AND metadata_visibility:("Public"))'
 
         except Exception:
             if 'fq' in search_params:


### PR DESCRIPTION
Filter queries can use `OR` or `AND` as the default operator.
This sets the default to `AND` so that expressions such as:

```
fq=res_format:"pdf" license_id:"2" sector:"Health and Safety" +(edc_state:("PUBLISHED"+OR+"PENDING+ARCHIVE") AND metadata_visibility:("Public"))
```

each filter will be `AND'd`  Else they will be `OR'd`