### PR TITLE
403 - Showing tracking count on datasets

### DIFF
--- a/ckanext/bcgov/templates/package/read.html
+++ b/ckanext/bcgov/templates/package/read.html
@@ -91,9 +91,11 @@
     {% set tracking_summary = h.get_package_tracking(pkg['id']) %}
     {% if tracking_summary %}
       <h4 class="description-tracking">
-      {% if tracking_summary.views.total > -1 %} <span class="flex-1">Total Views: {{ tracking_summary.views.total}}</span> {% endif %}
-      {% if tracking_summary.views.recent > -1 %} <span class="flex-1">Recent Views: {{ tracking_summary.views.recent }}</span> {% endif %}  
-      {% if tracking_summary.downloads > -1 %} <span class="flex-1">Downloads: {{ tracking_summary.downloads }}</span> {% endif %}  
+        {% if tracking_summary.views.total == 1 %}
+          {{ tracking_summary.views.total}} view ({{ tracking_summary.views.recent }} recent)
+        {% else %}
+          {{ tracking_summary.views.total}} views ({{ tracking_summary.views.recent }} recent)
+        {% endif %}
       </h4>
     {% endif %}
 

--- a/ckanext/bcgov/templates/snippets/package_item.html
+++ b/ckanext/bcgov/templates/snippets/package_item.html
@@ -132,6 +132,7 @@ Example:
           </ul>
         {% endblock %}
 
+        {#
         {% if tracking_summary %}
           <ul class="dataset-dates">
             {% if tracking_summary.views.total %}
@@ -145,6 +146,7 @@ Example:
             {% endif %}
           </ul>
         {% endif %}
+        #}
       </div>
     {% endblock %}
   </li>


### PR DESCRIPTION
#403  Using mockup on the dataset pages, commented out the tracking info on the dataset list pages