### PR TITLE
#501 - Revert resource_storage_location validator

### DIFF
--- a/ckanext/bcgov/forms/edc_datasets.py
+++ b/ckanext/bcgov/forms/edc_datasets.py
@@ -131,7 +131,7 @@ class EDC_GeoSpatialForm(edc_form.EDC_DatasetForm):
             'format': [not_empty, unicode],
             'edc_resource_type': [not_empty, convert_to_extras],
             'resource_storage_access_method': [not_empty, convert_to_extras],
-            'resource_storage_location': [not_empty, unicode, convert_to_extras],
+            'resource_storage_location': [ignore_missing, unicode, convert_to_extras],
             'data_collection_start_date': [ignore_missing, valid_date, convert_to_extras],
             'data_collection_end_date': [ignore_missing, valid_date, convert_to_extras],
             'ofi': [ignore_missing, bool, convert_to_extras]
@@ -232,7 +232,7 @@ class EDC_NonGeoSpatialForm(edc_form.EDC_DatasetForm):
             'format': [not_empty, unicode],
             'edc_resource_type': [not_empty, convert_to_extras],
             'resource_storage_access_method': [not_empty, convert_to_extras],
-            'resource_storage_location': [not_empty, unicode, convert_to_extras],
+            'resource_storage_location': [ignore_missing, unicode, convert_to_extras],
             'data_collection_start_date': [ignore_missing, valid_date, convert_to_extras],
             'data_collection_end_date': [ignore_missing, valid_date, convert_to_extras],
         })


### PR DESCRIPTION
#501

Can't use `not_empty` on resource_storage_location currently because when adding or updating resources, if that field is missing from other resources in the dataset, then the new or edited resource fails.