### PR TITLE
add 'aoi' to order to fix bug

### DIFF
--- a/ckanext/bcgov/fanstatic/edc_pow.js
+++ b/ckanext/bcgov/fanstatic/edc_pow.js
@@ -85,6 +85,7 @@ this.ckan.module('edc_pow', function($, _){
 			dwdspowapi.orderData = {
 				emailAddress: '',
 				aoiType: '0',
+				aoi: '',
 				orderingApplication: 'BCDC',
 				formatType: '3',
 				crsType: '4',


### PR DESCRIPTION
This is to fix the Issue with Mapsheet aoi calculation when ordering using the POW via BCDC.

'aoi' was missing from the JSON which submits the order.
