### PR TITLE
bug fix and parameterize defaults for edc_pow.js module

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,32 @@ Installation
         edc.environment_name = MYDEVBOX
 
         ...
-        
+
         # POW Settings
         bcgov.pow.env = test
-        bcgov.pow.secure_site = false
         bcgov.pow.past_orders_nbr = 5
-        bcgov.pow.custom_aoi_url = http://maps.gov.bc.ca/ess/hm/aoi/
+        bcgov.pow.custom_aoi_url = https://maps.gov.bc.ca/ess/hm/aoi/
         bcgov.pow.persist_config = true
         bcgov.pow.enable_mow = false
         bcgov.pow.user_pow_ofi = true
+        bcgov.pow.order_source = bcdc
+
+        # OFI endpoint defaults:
+        bcgov.pow.ofi_endpoint.url = apps.gov.bc.ca/pub/dwds-ofi
+        bcgov.pow.ofi_endpoint.protocol = https
+        bcgov.pow.ofi_endpoint.pow_ui_path = /jsp/dwds_pow_current_order.jsp?
+
+        # Order Defaults:
+        bcgov.pow.order_details.aoi_type = 0
+        bcgov.pow.order_details.aoi =
+        bcgov.pow.order_details.ordering_application = BCDC
+        bcgov.pow.order_details.format_type = 3
+        bcgov.pow.order_details.csr_type = 4
+        bcgov.pow.order_details.item.metadata_url = https://catalogue.data.gov.bc.ca/dataset/
+
+_Note:_
+* For `format_type` see https://github.com/bcgov/ckanext-bcgov/issues/400#issuecomment-367504526
+* For `CSR types` see https://apps.gov.bc.ca/pub/dwds-ofi/info/crsTypes
 
 
 4.  Update (or create) `import.ini` file inside `ckanext-bcgov/ckanext/bcgov/scripts/config`. Add `api_key`, `site_url` options (they should be the same as in your CKAN `.ini` file).

--- a/ckanext/bcgov/fanstatic/edc_pow.js
+++ b/ckanext/bcgov/fanstatic/edc_pow.js
@@ -13,9 +13,10 @@ this.ckan.module('edc_pow', function($, _){
 
 	return {
 		/*
-		I've parameterized default settings.
+		defaults have been parameterized.
 		Parameters passed to the module:
 
+		General params:
 		* env
 		* pkg
 		* secure_site
@@ -31,12 +32,12 @@ this.ckan.module('edc_pow', function($, _){
 		* ofi_endpoint_pow_ui_path
 
 		Order defaults:
-			aoi_type
-			aoi
-			ordering_application
-			format_type
-			crs_type
-			metada_url
+		* aoi_type
+		* aoi
+		* ordering_application
+		* format_type
+		* crs_type
+		* metada_url
 		*/
 
 		initialize: function() {

--- a/ckanext/bcgov/fanstatic/edc_pow.js
+++ b/ckanext/bcgov/fanstatic/edc_pow.js
@@ -8,25 +8,36 @@ this.ckan.module('edc_pow', function($, _){
 	var get_dwds_url = function(endpoint) {
 		const env = (opt.env) ? opt.env + '.' : '';
 		endpoint = (endpoint.charAt(0) !== '/') ? '/' + endpoint : endpoint;
-		return 'https://' + env + 'apps.gov.bc.ca/pub/dwds-ofi' + endpoint;
+		return opt.ofi_protocol + '://' + env + opt.ofi_url + endpoint;
 	};
 
 	return {
-		options: {
-			// // TODO: parameterize values from ckan.ini rather than hard-code
-			// env: 'delivery',
-			pkg: {
-				object_name: '',
-				id: '',
-				title: '',
-				name: '',
-			},
-			secure_site: false,
-			past_orders_nbr: '5',
-			custom_aoi_url: 'http://maps.gov.bc.ca/ess/hm/aoi/',
-			persist_config: true,
-			use_pow_ui: true
-		},
+		/*
+		I've parameterized default settings.
+		Parameters passed to the module:
+
+		* env
+		* pkg
+		* secure_site
+		* past_orders_nbr
+		* custom_aoi_url
+		* persist_config
+		* user_pow_ui
+		* order_source
+
+		OFI Endpoint defaults:
+		* ofi_endpoint_url
+		* ofi_endpoint_protocol
+		* ofi_endpoint_pow_ui_path
+
+		Order defaults:
+			aoi_type
+			aoi
+			ordering_application
+			format_type
+			crs_type
+			metada_url
+		*/
 
 		initialize: function() {
 			console.log('initializing module "edc_pow"');
@@ -37,7 +48,11 @@ this.ckan.module('edc_pow', function($, _){
 			//
 			// set an empty string for `env`, indicates to not use a bcgov subdomain environment
 			// eg. use prod if env isn't set in the config
-			this.options.env = (!(this.options.env instanceof String) || (this.options.env instanceof Boolean)) && '';
+			this.options.env = (typeof this.options.env == "string" && this.options.env.length == 0) || typeof this.options.env == "boolean" ? '' : String(this.options.env)
+			// do the same for api
+			this.options.aoi = (typeof this.options.aoi == "string" && this.options.aoi.length == 0) || typeof this.options.aoi == "boolean" ? '' : String(this.options.aoi)
+			console.log("this.options");
+			console.log(this.options);
 
 			// convinence option vars
 			self = this;
@@ -84,11 +99,11 @@ this.ckan.module('edc_pow', function($, _){
 
 			dwdspowapi.orderData = {
 				emailAddress: '',
-				aoiType: '0',
-				aoi: '',
-				orderingApplication: 'BCDC',
-				formatType: '3',
-				crsType: '4',
+				aoiType: opt.api_type,
+				aoi: opt.aoi,
+				orderingApplication: opt.ordering_application,
+				formatType: opt.format_type,
+				crsType: opt.crs_type,
 				prepackagedItems: '',
 				featureItems: [
 					{
@@ -97,7 +112,7 @@ this.ckan.module('edc_pow', function($, _){
 						layerMetadataUrl: null,
 						layerName: pkg.title,
 						filterType: 'No Filter',
-						layerMetadataUrl: 'https://catalogue.data.gov.bc.ca/dataset/' + pkg.name,
+						layerMetadataUrl: opt.metadata_url + pkg.name,
 						pctOfMax: null
 					}
 				],
@@ -122,11 +137,11 @@ this.ckan.module('edc_pow', function($, _){
 				customAoiUrl: opt.custom_aoi_url,
 				pastOrdersNbr: opt.past_orders_nbr,
 				secureSite: opt.secure_site,
-				orderSource: 'imap4m'
+				orderSource: opt.order_source
 			};
 
 			// Create url with query params from above
-			var url = get_dwds_url('/jsp/dwds_pow_current_order.jsp?') + $.param(qs);
+			var url = get_dwds_url(opt.ofi_pow_ui_path) + $.param(qs);
 
 			window.open(url, "_blank", "resizable=yes, scrollbars=yes, titlebar=yes, width=800, height=900, top=10, left=10");
 		},

--- a/ckanext/bcgov/templates/package/resource_read.html
+++ b/ckanext/bcgov/templates/package/resource_read.html
@@ -211,7 +211,23 @@
           data-module-past_orders_nbr="{{ pow_config['past_orders_nbr'] }}"
           data-module-custom_aoi_url="{{ pow_config['custom_aoi_url'] }}"
           data-module-persist_config="{{ pow_config['persist_config'] }}"
-          data-module-use_pow_ui="{{ pow_config['use_pow_ui'] }}"></div>
+          data-module-use_pow_ui="{{ pow_config['use_pow_ui'] }}"
+          data-module-order_source="{{ pow_config['order_source'] }}"
+
+          {% OFI endpoint defaults %}
+          data-module-ofi_url="{{ pow_config['ofi_endpoint.url'] }}"
+          data-module-ofi_protocol="{{ pow_config['ofi_endpoint.protocol'] }}"
+          data-module-ofi_pow_ui_path="{{ pow_config['ofi_endpoint.pow_ui_path'] }}"
+
+          {% Order defaults %}
+          data-module-aoi_type="{{ pow_config['order_details.aoi_type'] }}"
+          data-module-aoi="{{ pow_config['order_details.aoi'] }}"
+          data-module-ordering_application="{{ pow_config['order_details.ordering_application'] }}"
+          data-module-format_type="{{ pow_config['order_details.format_type'] }}"
+          data-module-csr_type="{{ pow_config['order_details.csr_type'] }}"
+          data-module-metadata_url="{{ pow_config['order_details.item.metadata_url'] }}"
+          >
+        </div>
 
         {% resource 'edc_resource/edc_pow.js' %}
       {% endif %}


### PR DESCRIPTION
## The bug fix

Passing empty values to the module defaulted to a boolean value.
This is documented in  https://github.com/ckan/ckan/issues/3287
The "fix" looked like it worked but didn't.  regardless of the setting the value was set to the empty string.
This code doesn't work:
```javascript
this.options.env = (!(this.options.env instanceof String) || (this.options.env instanceof Boolean)) && '';
```
This code Does:
```javascript
this.options.env = (typeof this.options.env == "string" && this.options.env.length == 0) || typeof this.options.env == "boolean" ? '' : String(this.options.env)
```
I did this for the `AOI` parameter also.

## Parameterization

The rest of the changes were simply setting, naming and passing default settings to the module.

I also updated the README.md to reflect this.