### PR TITLE
correct ofi_config settings usage

### DIFF
--- a/ckanext/bcgov/util/helpers.py
+++ b/ckanext/bcgov/util/helpers.py
@@ -552,24 +552,13 @@ def get_pow_config():
 
 
 def _build_ofi_url(secure=False):
-    '''
-    TODO
-    '''
-    import urlparse
     ofi_config = get_ofi_config()
-    protocol = ofi_config.get(u'protocol', 'https')
-    domain = ofi_config.get(u'hostname', 'delivery.apps.gov.bc.ca')
-    port = ofi_config.get(u'port', '')
-
-    if port != '':
-        domain = u'{}:{}'.format(domain, port)
 
     if secure:
-        order_path = ofi_config.get(u'order_secure_path', '/pub/dwds-ofi/secure')
+        url = ofi_config.get(u'secure_url', 'https://delivery.apps.gov.bc.ca/pub/dwds-ofi/secure')
     else:
-        order_path = ofi_config.get(u'order_path', '/pub/dwds-ofi')
+        url = ofi_config.get(u'public_url', 'https://delivery.apps.gov.bc.ca/pub/dwds-ofi')
 
-    url = urlparse.urlunparse((protocol, domain, order_path, '', '', ''))
     log.debug(u'OFI base API URL: %s', url)
     return url
 

--- a/ckanext/bcgov/util/helpers.py
+++ b/ckanext/bcgov/util/helpers.py
@@ -555,9 +555,9 @@ def _build_ofi_url(secure=False):
     ofi_config = get_ofi_config()
 
     if secure:
-        url = ofi_config.get(u'secure_url', 'https://delivery.apps.gov.bc.ca/pub/dwds-ofi/secure')
+        url = ofi_config.get(u'secure_url', 'https://apps.gov.bc.ca/pub/dwds-ofi/secure')
     else:
-        url = ofi_config.get(u'public_url', 'https://delivery.apps.gov.bc.ca/pub/dwds-ofi')
+        url = ofi_config.get(u'public_url', 'https://apps.gov.bc.ca/pub/dwds-ofi')
 
     log.debug(u'OFI base API URL: %s', url)
     return url


### PR DESCRIPTION
This chunk of code was using old ofi_config settings that are no longer valid.
This was causing an error in TEST when attempting to add an OFI resourse: the delivery OFI API was being called.