### PR TITLE
set logic PROD only

### DIFF
--- a/ckanext/bcgov/templates/base.html
+++ b/ckanext/bcgov/templates/base.html
@@ -157,7 +157,7 @@
 	</noscript>
 	<!-- END OF SmartSource Data Collector TAG -->
 
-  {% if h.get_environment_name() != 'DLV' and h.get_environment_name() == 'TST' %}
+  {% if h.get_environment_name() != 'DLV' and h.get_environment_name() != 'TST' %}
   // <!-- Snowplow starts plowing - Standalone Search v1.2.9.3 -->
   <script type="text/javascript">
   ;(function(p,l,o,w,i,n,g){if(!p[i]){p.GlobalSnowplowNamespace=p.GlobalSnowplowNamespace||[];


### PR DESCRIPTION
It was necessary to activate the snowplow snippet in TEST, so that the GDX team could assert their changes worked.
This change de-activates this snipped in TEST.
The snipped will only be activated in PROD.