### PR TITLE
Sprint 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-[![Join us on Slack](https://cldup.com/jWUT4QFLnq.png)](https://devopspathfinder.slack.com/messages/C915T1NEP)[![Build Status](https://cis.data.gov.bc.ca/buildStatus/icon?job=bcdc/caddi)](https://cis.data.gov.bc.ca/job/bcdc/job/caddi/)[![License](https://img.shields.io/badge/license-AGPL-blue.svg)](https://raw.githubusercontent.com/bcgov/ckanext-bcgov/master/license)<a rel="Delivery" href="https://github.com/BCDevExchange/docs/blob/master/discussion/projectstates.md"><img alt="In production, but maybe in Alpha or Beta. Intended to persist and be supported." style="border-width:0" src="https://assets.bcdevexchange.org/images/badges/delivery.svg" title="In production, but maybe in Alpha or Beta. Intended to persist and be supported." /></a>
+[![Join us on Slack](https://img.shields.io/badge/Join%20us%20on-Slack-ff69b4.svg)](https://devopspathfinder.slack.com/messages/C915T1NEP)
+[![Build Status](https://cis.data.gov.bc.ca/buildStatus/icon?job=bcdc/caddi)](https://cis.data.gov.bc.ca/job/bcdc/job/caddi/)
+[![License](https://img.shields.io/badge/license-AGPL-blue.svg)](https://raw.githubusercontent.com/bcgov/ckanext-bcgov/master/license)
+[![Delivery](https://assets.bcdevexchange.org/images/badges/delivery.svg)](https://github.com/BCDevExchange/docs/blob/master/discussion/projectstates.md)
+
 
 ckanext-bcgov
 =============
@@ -21,48 +25,53 @@ Installation
 
 4.  Add the following lines to ini file to the search setting section if they don’t exist:
 
-        search.facets.limit = 500
-        search.facets.default = 20
-        ckan.search.show_all_types = true
+```
+# solr related settings
+search.facets.limit = 500
+search.facets.default = 20
+ckan.search.show_all_types = true
+ckan.api_key = your-sysadmin-api-key
 
-        ...
+# licenses and sectors JSON files, e.g.:
+licenses_group_url = https://${BCDC_LICENSE_API_ENDPOINT}/bcdc_licenses.json
+sectors_file_url = https://${BCDC_LICENSE_API_ENDPOINT}/bcdc_sectors.json
 
-        ckan.api_key = your-sysadmin-api-key
+# (optional) Environment name
+edc.environment_name = MYDEVBOX
 
-        ...
+# Dashboard settings
+bcgov.dashboard.api_url = https://argg.apps.gov.bc.ca/int/
 
-        # Path for licenses and sectors JSON files, e.g.:
-        licenses_group_url = https://$GOGS_URL/bcdc-licenses-data/edc_licenses.json
-        sectors_file_url = https://$GOGS_URL/bcdc-licenses-data/edc_sectors.json
+# OFI Service endpoint
+bcgov.ofi.api.public_url = https://apps.gov.bc.ca/pub/dwds-ofi
+bcgov.ofi.api.secure_url = https://apps.gov.bc.ca/pub/dwds-ofi/secure
+bcgov.ofi.api.convert_to_single_res = true
 
-        ...
+# POW Service Endpoints
+bcgov.pow.public_url = https://apps.gov.bc.ca/pub/dwds-ofi
+# Siteminder enabled POW is enabled.
+bcgov.pow.secure_url = https://apps.gov.bc.ca/ext/dwds-pow
+bcgov.pow.pow_ui_path = /jsp/dwds_pow_current_order.jsp?
 
-        # (optional) Environment name
-        edc.environment_name = MYDEVBOX
+# POW Settings
+bcgov.pow.env = prod
+bcgov.pow.past_orders_nbr = 5
+bcgov.pow.custom_aoi_url = http://maps.gov.bc.ca/ess/hm/aoi/
+bcgov.pow.persist_config = true
+bcgov.pow.enable_mow = false
+bcgov.pow.user_pow_ofi = true
+bcgov.pow.order_source = bcdc
 
-        ...
+# POW Order Defaults
+bcgov.pow.order_details.aoi_type = 0
+bcgov.pow.order_details.aoi =
+bcgov.pow.order_details.clipping_method_type_id = 1
+bcgov.pow.order_details.ordering_application = BCDC
+bcgov.pow.order_details.format_type = 3
+bcgov.pow.order_details.csr_type = 4
+bcgov.pow.order_details.item.metadata_url = https://catalogue.data.gov.bc.ca/dataset/
 
-        # POW Settings
-        bcgov.pow.env = test
-        bcgov.pow.past_orders_nbr = 5
-        bcgov.pow.custom_aoi_url = https://maps.gov.bc.ca/ess/hm/aoi/
-        bcgov.pow.persist_config = true
-        bcgov.pow.enable_mow = false
-        bcgov.pow.user_pow_ofi = true
-        bcgov.pow.order_source = bcdc
-
-        # OFI endpoint defaults:
-        bcgov.pow.ofi_endpoint.url = apps.gov.bc.ca/pub/dwds-ofi
-        bcgov.pow.ofi_endpoint.protocol = https
-        bcgov.pow.ofi_endpoint.pow_ui_path = /jsp/dwds_pow_current_order.jsp?
-
-        # Order Defaults:
-        bcgov.pow.order_details.aoi_type = 0
-        bcgov.pow.order_details.aoi =
-        bcgov.pow.order_details.ordering_application = BCDC
-        bcgov.pow.order_details.format_type = 3
-        bcgov.pow.order_details.csr_type = 4
-        bcgov.pow.order_details.item.metadata_url = https://catalogue.data.gov.bc.ca/dataset/
+```
 
 _Note:_
 * For `format_type` see https://github.com/bcgov/ckanext-bcgov/issues/400#issuecomment-367504526

--- a/ckanext/bcgov/fanstatic/edc_restrict_browser.js
+++ b/ckanext/bcgov/fanstatic/edc_restrict_browser.js
@@ -70,16 +70,17 @@ function isUsingSupportedBrowser() {
 }
 
 $(function() {
-	if(!isUsingSupportedBrowser()) {
-		
-		// Remove page content
-		var $primaryDiv = $('.primary div.module-content')
-		$primaryDiv.html('');
-
-		// Insert a warning
-		var warningText = "You are attempting to update or edit BC Data Catalogue content using a non-supported web browser or version. Supported browsers are Google Chrome (downloadable from <a href=\"https://www.google.com/chrome/\" target=\"_blank\">https://www.google.com/chrome/</a>) and Firefox (downloadable from <a href=\"https://www.mozilla.org/en-US/firefox/new/\" target=\"_blank\">https://www.mozilla.org/en_US/firefox/new/</a>). Not all version of these browsers are supported. If you are seeing this message and you are using Firefox or Chrome, then please report this problem to DataBC Catalogue Services.";
-		var $warningDiv = $('<div>' + warningText + "</div>").addClass('alert alert-danger');
-		$primaryDiv.prepend($warningDiv);
-		
-	}
+	//Ckanext-bcgov#685 remove check
+	// if(!isUsingSupportedBrowser()) {
+	//
+	// 	// Remove page content
+	// 	var $primaryDiv = $('.primary div.module-content')
+	// 	$primaryDiv.html('');
+	//
+	// 	// Insert a warning
+	// 	var warningText = "You are attempting to update or edit BC Data Catalogue content using a non-supported web browser or version. Supported browsers are Google Chrome (downloadable from <a href=\"https://www.google.com/chrome/\" target=\"_blank\">https://www.google.com/chrome/</a>) and Firefox (downloadable from <a href=\"https://www.mozilla.org/en-US/firefox/new/\" target=\"_blank\">https://www.mozilla.org/en_US/firefox/new/</a>). Not all version of these browsers are supported. If you are seeing this message and you are using Firefox or Chrome, then please report this problem to DataBC Catalogue Services.";
+	// 	var $warningDiv = $('<div>' + warningText + "</div>").addClass('alert alert-danger');
+	// 	$primaryDiv.prepend($warningDiv);
+	//
+	// }
 });

--- a/ckanext/bcgov/templates/ofi/snippets/geo_resource_form.html
+++ b/ckanext/bcgov/templates/ofi/snippets/geo_resource_form.html
@@ -74,6 +74,15 @@
 </div>
 
 <!-- This is to force the popover to activate in the modal, it doesn't work without for some reason -->
-<script type="text/javascript">$(document).ready(function(){$('a[href="#markdown"]').popover()});</script>
+<script type="text/javascript">
+	$(document).ready(function(){$('a[href="#markdown"]').popover()});
+	$('body').on('click', function (e) {
+		//did not click a popover toggle or popover
+		if ($(e.target).data('target') !== 'popover'
+			&& $(e.target).parents('.popover.in').length === 0) {
+			$('[data-original-title]').popover('hide');
+		}
+	});
+</script>
 
 <!--Snippet ofi/snippets/geo_resource_form.html end -->

--- a/ckanext/bcgov/templates/package/snippets/additional_info.html
+++ b/ckanext/bcgov/templates/package/snippets/additional_info.html
@@ -11,15 +11,18 @@
           {% endif %}
 
           {% if pkg.type == "Geographic" or pkg.type == "Dataset" %}
-           <tr>
+            {% if pkg.data_quality %}
+            <tr>
               <td width="150px"><strong>Data Quality</strong></td>
               <td>{{ h.render_markdown(pkg.data_quality) }}</td>
             </tr>
-
+            {% endif %}
+            {% if pkg.lineage_statement %}
             <tr>
               <td><strong>Lineage Statement</strong></td>
               <td>{{ h.render_markdown(pkg.lineage_statement) }}</td>
             </tr>
+            {% endif %}
           {% endif %}
         </table>
       {% endif %}


### PR DESCRIPTION

This includes 3 bug fixes and work from @BrandonSharratt @jachurchill for sprint 5.

| issue | PR | title | 
|-- |--|--|
|[685](https://github.com/bcgov/ckanext-bcgov/issues/685)| [PR 697](https://github.com/bcgov/ckanext-bcgov/pull/697) |Remove browser checking when adding or editing datasets|
|[683](https://github.com/bcgov/ckanext-bcgov/issues/683)| [PR 699](https://github.com/bcgov/ckanext-bcgov/pull/699)|Formatting of data elements: Data Quality is empty and should not be   presented. |
|[687](https://github.com/bcgov/ckanext-bcgov/issues/687)| [PR 705](https://github.com/bcgov/ckanext-bcgov/pull/705) | Markdown modal help pop up does not close|

