### PR TITLE
Update schema for bcgov/ckan-ui#495

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ ckantoolkit
 ckanapi
 ckanext-pdfview==0.0.5
 -e git+https://github.com/bcgov/ckanext-sso@ac78637a1aa33b16cf8781bd47626c7a9d10f6c5#egg=ckanext_sso
--e git+https://github.com/bcgov/ckanext-bcgov-schema@45e737077148342051b6b93af6c02d98fdbfdca7#egg=ckanext_bcgov_schema
+-e git+https://github.com/bcgov/ckanext-bcgov-schema@123548effb120ce2c2d8edb4cbc365e409946655#egg=ckanext_bcgov_schema
 -e git+https://github.com/ckan/ckanext-scheming@1a096dd963424884bbaf70fa28da5c1de058d27d#egg=ckanext_scheming
 -e git+https://github.com/open-data/ckanext-repeating@291295557ff74b26784f6271c1a1b4ffdb990f43#egg=ckanext_repeating
 -e git+https://github.com/EnviDat/ckanext-composite@23a060b03d2432a58cc66968d93a15f5f1654055#egg=ckanext_composite


### PR DESCRIPTION
In this change, I reference the latest version of schema. This changes the `notes` field to `description` for groups and organizations.