### PR TITLE
Bump edc-rss version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ cachetools==3.1.1
 -e git+https://github.com/ckan/ckan.git@ckan-2.7.5#egg=ckan
 -e git+https://github.com/ckan/ckanext-geoview@v0.0.15#egg=ckanext_geoview
 -e git+https://github.com/okfn/ckanext-envvars.git@8602376a92a77b4f2d41763b6823d041469fa08e#egg=ckanext_envvars
--e git+https://github.com/bcgov/ckanext-edc-rss.git@v1.0.0#egg=ckanext-edc-rss
+-e git+https://github.com/bcgov/ckanext-edc-rss.git@v2.0.0#egg=ckanext-edc-rss
 -e git+https://github.com/bcgov/ckanext-ga-report@1ddfcdcee5e7a21fe0f756f0942a1cf1b9ad4692#egg=ckanext_ga_report
 -e git+https://github.com/bcgov/ckanext-googleanalytics@33356b9dec1ce33374b1004479d2b1c255028120#egg=ckanext_googleanalytics
 -e git+https://github.com/bcgov/ckanext-hierarchy@2e80d6790e7bbd95fea3fd1966adbb0f56af1104#egg=ckanext_hierarchy


### PR DESCRIPTION
To enable the RSS feed in beta catalogue, bumping the edc-rss version to 2.0.0.