### PR TITLE
Switched to edismax for search

### DIFF
--- a/ckanext/bcgov/plugin.py
+++ b/ckanext/bcgov/plugin.py
@@ -269,6 +269,9 @@ class SchemaPlugin(plugins.SingletonPlugin):
 
     # IPackageController
     def before_search(self, search_params):
+
+        if not search_params.get('defType', ''):
+            search_params['defType'] = 'edismax' # use edismax if query type unspecified
         
         if c.userobj and c.userobj.sysadmin is True:
             return search_params


### PR DESCRIPTION
To benefit from some of the newer features of the edismax query parser, I've set it to the default for incoming searches.

https://stackoverflow.com/questions/13601853/what-is-the-difference-between-dismax-and-edismax