### PR TITLE
Fix error when package_search is used with field list

### DIFF
--- a/ckanext/bcgov/plugin.py
+++ b/ckanext/bcgov/plugin.py
@@ -325,8 +325,9 @@ class SchemaPlugin(plugins.SingletonPlugin):
 
         # remove private groups from individual search results
         for result in results:
-            result["groups"] = [group for group in result["groups"]
-                                if can_access_group(group["id"])]
+            if result.get("groups"):
+                result["groups"] = [group for group in result["groups"]
+                                    if can_access_group(group["id"])]
 
         return search_results
 


### PR DESCRIPTION
Although the syntax is a little bit awkward, it is possible to pass a field list to package_search. Currently, an error is thrown due to some code that assumes the `group` key is present in each search result. This fixes that error so the following API call can work:

  /api/3/action/package_search?q=&fl=name&fl=name