### PR TITLE
Added whoami endpoint

### DIFF
--- a/ckanext/bcgov/logic/action.py
+++ b/ckanext/bcgov/logic/action.py
@@ -52,6 +52,15 @@ log = logging.getLogger('ckanext.edc_schema')
 _or_ = sqlalchemy.or_
 
 @toolkit.side_effect_free
+def whoami(context, data_dict):
+    '''Get the user id for the currently logged in user
+
+    :rtype string'''
+
+
+    return toolkit.c.user
+
+@toolkit.side_effect_free
 def organization_list_related(context, data_dict):
     '''Return a list of the names of the site's organizations.
 

--- a/ckanext/bcgov/plugin.py
+++ b/ckanext/bcgov/plugin.py
@@ -392,7 +392,8 @@ class SchemaPlugin(plugins.SingletonPlugin):
             'ofi_create_order': ofi.ofi_create_order,
             'tag_autocomplete_by_vocab': edc_action.tag_autocomplete_by_vocab,
             'member_list': edc_action.member_list,
-            'organization_list_related': edc_action.organization_list_related
+            'organization_list_related': edc_action.organization_list_related,
+            'whoami': edc_action.whoami
         }
 
     def get_auth_functions(self):


### PR DESCRIPTION
Added an API endpoint `/api/3/action/whoami` to identify the currently logged in user. This is so the UI doesn't have to use heuristics to [extract that id from activity feed information](https://github.com/bcgov/ckan-ui/blob/eb92f8aca0bd254254ce185113cd56140fadcc9d/frontend/src/components/pages/user.vue#L77:L86).